### PR TITLE
feat: Implement new PCWT registration number format with 5-character …

### DIFF
--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -671,8 +671,10 @@ def import_csv(request):
                     existing_participant.save()
                     results['updated'] += 1
                 else:
-                    # Create new participant
-                    registration_number = generate_registration_number()
+                    # Create new participant using new PCWT format
+                    full_name = participant_data.get('full_name')
+                    age = participant_data.get('age')
+                    registration_number = generate_registration_number(full_name, age)
                     Participant.objects.create(
                         registration_number=registration_number,
                         is_spot_registration=False,

--- a/participants/utils.py
+++ b/participants/utils.py
@@ -1,13 +1,55 @@
 import re
+import uuid
 from datetime import datetime
 from django.db import models
 from django.utils import timezone
 from .models import Participant
 
 
-def generate_registration_number():
+def extract_name_part(full_name, length):
     """
-    Generate unique registration number
+    Extract first N characters from full name, handling edge cases
+    """
+    if not full_name:
+        return "XX"  # Default for missing names
+    
+    # Clean and extract first characters (remove spaces, special chars)
+    clean_name = re.sub(r'[^A-Za-z]', '', full_name.upper())
+    
+    if len(clean_name) < length:
+        return clean_name.ljust(length, 'X')  # Pad with X
+    
+    return clean_name[:length]
+
+
+def generate_pcwt_registration_number(full_name, age):
+    """
+    Generate PCWT format registration number: PCWT + age(2) + name(2) + uuid(5)
+    Format: PCWT25JOA1B2C (13 characters total)
+    """
+    # Extract first 2 characters of name
+    name_part = extract_name_part(full_name, 2)
+    
+    # Format age as 2 digits
+    age_str = f"{age:02d}" if age else "00"
+    
+    # Generate 5-character UUID part
+    uuid_part = str(uuid.uuid4())[:5].upper()
+    
+    # Combine: PCWT + age + name + uuid
+    registration_number = f"PCWT{age_str}{name_part}{uuid_part}"
+    
+    # Ensure uniqueness (very unlikely to need retry with 5-char UUID)
+    while Participant.objects.filter(registration_number=registration_number).exists():
+        uuid_part = str(uuid.uuid4())[:5].upper()
+        registration_number = f"PCWT{age_str}{name_part}{uuid_part}"
+    
+    return registration_number
+
+
+def generate_registration_number_fallback():
+    """
+    Generate fallback registration number (original format)
     """
     prefix = 'REG'
     year = datetime.now().year % 100  # Last 2 digits of year
@@ -34,6 +76,17 @@ def generate_registration_number():
         registration_number = f"{prefix}{year:02d}{next_number:04d}"
     
     return registration_number
+
+
+def generate_registration_number(full_name=None, age=None):
+    """
+    Main function to generate registration number with fallback
+    Uses new PCWT format if name and age are provided, otherwise falls back to original format
+    """
+    if full_name and age is not None:
+        return generate_pcwt_registration_number(full_name, age)
+    else:
+        return generate_registration_number_fallback()
 
 
 def clean_participant_data(raw_data):

--- a/participants/views.py
+++ b/participants/views.py
@@ -54,8 +54,11 @@ class ParticipantListCreateView(generics.ListCreateAPIView):
         if self.request.user.role not in ['registration_desk', 'admin']:
             raise PermissionDenied('Registration desk access required')
         
-        # Generate registration number
-        registration_number = generate_registration_number()
+        # Generate registration number using new PCWT format
+        full_name = serializer.validated_data.get('full_name')
+        age = serializer.validated_data.get('age')
+        registration_number = generate_registration_number(full_name, age)
+        
         serializer.save(
             registration_number=registration_number,
             is_spot_registration=True

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -150,8 +150,8 @@ router.post('/import/csv', authenticateToken, requireAdmin, upload.single('csvFi
                 results.updated++;
                 console.log(`Updated existing participant: ${participant.full_name}`);
               } else {
-                // Create new participant
-                const registrationNumber = await generateRegistrationNumber();
+                // Create new participant using new PCWT format
+                const registrationNumber = await generateRegistrationNumber(participant.full_name, participant.age);
                 console.log(`Generating registration number: ${registrationNumber} for ${participant.full_name}`);
                 
                 await runQuery(`

--- a/src/routes/participants.js
+++ b/src/routes/participants.js
@@ -191,8 +191,8 @@ router.post('/', [
       });
     }
 
-    // Generate unique registration number
-    const registrationNumber = await generateRegistrationNumber();
+    // Generate unique registration number using new PCWT format
+    const registrationNumber = await generateRegistrationNumber(full_name, age);
 
     // Create participant
     const result = await runQuery(

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,7 +1,59 @@
 const { getQuery, runQuery } = require('./database');
 
-// Generate unique registration number
-const generateRegistrationNumber = async () => {
+// Extract name part for registration number
+const extractNamePart = (fullName, length) => {
+  if (!fullName) {
+    return 'XX'.padEnd(length, 'X'); // Default for missing names
+  }
+  
+  // Clean and extract first characters (remove spaces, special chars)
+  const cleanName = fullName.replace(/[^A-Za-z]/g, '').toUpperCase();
+  
+  if (cleanName.length < length) {
+    return cleanName.padEnd(length, 'X'); // Pad with X
+  }
+  
+  return cleanName.substring(0, length);
+};
+
+// Generate PCWT format registration number
+const generatePCWTRegistrationNumber = async (fullName, age) => {
+  try {
+    // Extract first 2 characters of name
+    const namePart = extractNamePart(fullName, 2);
+    
+    // Format age as 2 digits
+    const ageStr = age ? age.toString().padStart(2, '0') : '00';
+    
+    // Generate 5-character UUID part
+    const uuidPart = require('crypto').randomUUID().substring(0, 5).toUpperCase();
+    
+    // Combine: PCWT + age + name + uuid
+    let registrationNumber = `PCWT${ageStr}${namePart}${uuidPart}`;
+    
+    // Ensure uniqueness (very unlikely to need retry with 5-char UUID)
+    const exists = await getQuery(
+      'SELECT id FROM participants WHERE registration_number = ?',
+      [registrationNumber]
+    );
+
+    if (exists) {
+      // Regenerate UUID part if collision (extremely rare)
+      const newUuidPart = require('crypto').randomUUID().substring(0, 5).toUpperCase();
+      registrationNumber = `PCWT${ageStr}${namePart}${newUuidPart}`;
+    }
+
+    console.log(`Generated PCWT registration number: ${registrationNumber}`);
+    return registrationNumber;
+  } catch (error) {
+    console.error('Error generating PCWT registration number:', error);
+    // Fallback to original format
+    return await generateRegistrationNumberFallback();
+  }
+};
+
+// Generate fallback registration number (original format)
+const generateRegistrationNumberFallback = async () => {
   try {
     const prefix = 'REG';
     const year = new Date().getFullYear().toString().slice(-2);
@@ -31,16 +83,25 @@ const generateRegistrationNumber = async () => {
 
     if (exists) {
       // If somehow it exists, try next number
-      return await generateRegistrationNumber();
+      return await generateRegistrationNumberFallback();
     }
 
-    console.log(`Generated registration number: ${registrationNumber}`);
+    console.log(`Generated fallback registration number: ${registrationNumber}`);
     return registrationNumber;
   } catch (error) {
-    console.error('Error generating registration number:', error);
+    console.error('Error generating fallback registration number:', error);
     // Fallback to timestamp-based number
     const timestamp = Date.now().toString().slice(-6);
     return `REG${timestamp}`;
+  }
+};
+
+// Main function to generate registration number with fallback
+const generateRegistrationNumber = async (fullName = null, age = null) => {
+  if (fullName && age !== null) {
+    return await generatePCWTRegistrationNumber(fullName, age);
+  } else {
+    return await generateRegistrationNumberFallback();
   }
 };
 


### PR DESCRIPTION
…UUID

✅ New Registration Number Format: PCWT + age(2) + name(2) + uuid(5)

## Format Details:
- PCWT: Prefix (4 chars)
- Age: 2-digit age (2 chars)
- Name: First 2 characters of full name (2 chars)
- UUID: 5-character random UUID (5 chars)
- Total Length: 13 characters

## Examples:
- PCWT25JOA1B2C (John, age 25)
- PCWT19JAA3D4E (Jane, age 19)
- PCWT30AHB5F6G (Ahmed, age 30)

## Implementation:
- Django: participants/utils.py - New PCWT generation functions
- Node.js: src/utils/helpers.js - Updated with PCWT format
- Views: Updated participant creation to use name + age
- CSV Import: Updated to use new format
- Fallback: Maintains original REG format for compatibility

## Benefits:
- Highly unique (1M+ UUID combinations)
- Human readable (age + name identification)
- Professional appearance
- Easy manual entry (13 characters)
- Backward compatible (fallback to REG format)

## Edge Case Handling:
- Missing names: Uses 'XX' default
- Single character names: Padded with 'X'
- Special characters: Cleaned and removed
- Collision detection: UUID regeneration

Ready for production use! 🚀📊