### PR TITLE
feat: Add PCWT logo to all pages and remove admin credentials from login

### DIFF
--- a/frontend/app/admin/dashboard/page.tsx
+++ b/frontend/app/admin/dashboard/page.tsx
@@ -123,17 +123,33 @@ export default function AdminDashboard() {
       <header className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
-              <p className="text-gray-600">Welcome back, {user.full_name}</p>
+            {/* Left Section - Title */}
+            <div className="flex items-center flex-1">
+              <div>
+                <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
+                <p className="text-gray-600">Welcome back, {user.full_name}</p>
+              </div>
             </div>
-            <button
-              onClick={handleLogout}
-              className="flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-            >
-              <LogOut className="w-4 h-4 mr-2" />
-              Logout
-            </button>
+            
+            {/* Center Section - Logo */}
+            <div className="flex justify-center flex-1">
+              <img 
+                src="/logo.png" 
+                alt="PCWT Logo" 
+                className="h-16 w-auto object-contain"
+              />
+            </div>
+            
+            {/* Right Section - Logout Button */}
+            <div className="flex justify-end flex-1">
+              <button
+                onClick={handleLogout}
+                className="flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+              >
+                <LogOut className="w-4 h-4 mr-2" />
+                Logout
+              </button>
+            </div>
           </div>
         </div>
       </header>

--- a/frontend/app/admin/results/page.tsx
+++ b/frontend/app/admin/results/page.tsx
@@ -152,7 +152,8 @@ export default function ViewResults() {
       <header className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
-            <div className="flex items-center">
+            {/* Left Section - Back Button and Title */}
+            <div className="flex items-center flex-1">
               <button
                 onClick={() => router.push('/admin/dashboard')}
                 className="mr-4 p-2 text-gray-400 hover:text-gray-600"
@@ -164,7 +165,18 @@ export default function ViewResults() {
                 <p className="text-gray-600">Competition results and rankings</p>
               </div>
             </div>
-            <div className="flex space-x-3">
+            
+            {/* Center Section - Logo */}
+            <div className="flex justify-center flex-1">
+              <img 
+                src="/logo.png" 
+                alt="PCWT Logo" 
+                className="h-16 w-auto object-contain"
+              />
+            </div>
+            
+            {/* Right Section - Action Buttons */}
+            <div className="flex justify-end items-center space-x-3 flex-1">
               <button
                 onClick={handleExportResults}
                 className="flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -194,7 +194,8 @@ export default function ManageUsers() {
       <header className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
-            <div className="flex items-center">
+            {/* Left Section - Back Button and Title */}
+            <div className="flex items-center flex-1">
               <button
                 onClick={() => router.push('/admin/dashboard')}
                 className="mr-4 p-2 text-gray-400 hover:text-gray-600"
@@ -206,7 +207,18 @@ export default function ManageUsers() {
                 <p className="text-gray-600">Manage competition participants</p>
               </div>
             </div>
-            <div className="flex space-x-3">
+            
+            {/* Center Section - Logo */}
+            <div className="flex justify-center flex-1">
+              <img 
+                src="/logo.png" 
+                alt="PCWT Logo" 
+                className="h-16 w-auto object-contain"
+              />
+            </div>
+            
+            {/* Right Section - Action Buttons */}
+            <div className="flex justify-end items-center space-x-3 flex-1">
               <button
                 onClick={handleExportParticipants}
                 className="flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -42,10 +42,16 @@ export default function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div>
-          <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-primary-100">
-            <BookOpen className="h-6 w-6 text-primary-600" />
+          {/* PCWT Logo */}
+          <div className="flex justify-center mb-8">
+            <img 
+              src="/logo.png" 
+              alt="PCWT Logo" 
+              className="h-24 w-auto object-contain"
+            />
           </div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          
+          <h2 className="text-center text-3xl font-extrabold text-gray-900">
             Essay Competition Management
           </h2>
           <p className="mt-2 text-center text-sm text-gray-600">
@@ -120,14 +126,6 @@ export default function LoginPage() {
             </button>
           </div>
 
-          <div className="text-center">
-            <p className="text-sm text-gray-600">
-              Default admin credentials: <br />
-              <span className="font-mono text-xs bg-gray-100 px-2 py-1 rounded">
-                username: admin, password: admin123
-              </span>
-            </p>
-          </div>
         </form>
       </div>
     </div>

--- a/frontend/app/registration/page.tsx
+++ b/frontend/app/registration/page.tsx
@@ -361,11 +361,23 @@ export default function RegistrationPage() {
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
-            <div>
+            {/* Left Section - Title */}
+            <div className="flex-1">
               <h1 className="text-2xl font-bold text-gray-900">Registration Desk</h1>
               <p className="text-sm text-gray-600">Search participants, validate details, and handle spot registrations</p>
             </div>
-            <div className="flex items-center space-x-4">
+            
+            {/* Center Section - Logo */}
+            <div className="flex justify-center flex-1">
+              <img 
+                src="/logo.png" 
+                alt="PCWT Logo" 
+                className="h-12 w-auto object-contain"
+              />
+            </div>
+            
+            {/* Right Section - User Info */}
+            <div className="flex justify-end items-center space-x-4 flex-1">
               <span className="text-sm text-gray-600">Welcome, {user.username}</span>
               <button
                 onClick={() => router.push('/login')}


### PR DESCRIPTION
- Added PCWT logo to login page center with bigger size (h-24)
- Removed admin credentials display from login page for security
- Added logo to all admin pages with consistent three-column header layout:
  - Admin Dashboard: Logo in center, title left, logout right
  - Admin Results: Logo in center, back button + title left, action buttons right
  - Admin Users: Logo in center, back button + title left, action buttons right
  - Live Stats: Already had logo (no changes needed)
- Added logo to Registration Desk page with three-column layout
- All logos use consistent styling: h-16 for admin pages, h-12 for registration
- Maintained responsive design with flex-1 sections for equal spacing
- Enhanced visual branding across the entire application